### PR TITLE
Fixed wrong uri paths from subresources

### DIFF
--- a/TypedRest/EndpointBase.cs
+++ b/TypedRest/EndpointBase.cs
@@ -41,7 +41,7 @@ namespace TypedRest
         /// <param name="parent">The parent endpoint containing this one.</param>
         /// <param name="relativeUri">The URI of this endpoint relative to the <paramref name="parent"/>'s.</param>
         protected EndpointBase(IEndpoint parent, Uri relativeUri)
-            : this(parent.HttpClient, new Uri(parent.Uri, relativeUri))
+            : this(parent.HttpClient, new Uri(parent.Uri.EnsureTrailingSlash(), relativeUri))
         {
         }
 

--- a/UnitTests/EndpointBaseTest.cs
+++ b/UnitTests/EndpointBaseTest.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace TypedRest
+{
+    [TestFixture]
+    public class EndpointBaseTest : EndpointTestBase
+    {
+        private ResourceCollectionEndpoint _endpoint;
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+            _endpoint = new ResourceCollectionEndpoint(EntryEndpoint,"resources");
+        }
+
+        [Test]
+        public void TestUriPathFromSubresourceContainsIdentitfier()
+        {
+            _endpoint["4711"].Subresource.Uri.ToString().Should().Be("http://localhost/resources/4711/subresource");
+        }
+
+        private class ResourceCollectionEndpoint : CollectionEndpointBase<MockEntity, ResourceEndpoint>
+        {
+            public ResourceCollectionEndpoint(IEndpoint parent, string relativeUri) : base(parent, relativeUri)
+            {
+            }
+
+            #region Overrides of CollectionEndpointBase<MockEntity,ResourceEndpoint>
+
+            public override ResourceEndpoint this[Uri relativeUri] => new ResourceEndpoint(this, relativeUri);
+
+            #endregion
+        }
+
+        private class ResourceEndpoint : ElementEndpoint<MockEntity>
+        {
+            public ResourceEndpoint(IEndpoint parent, Uri relativeUri) 
+                : base(parent, relativeUri)
+            {
+            }
+
+            public SubresourceEndpoint Subresource => new SubresourceEndpoint(this, "subresource");
+        }
+
+        private class SubresourceEndpoint : ElementEndpoint<MockEntity>
+        {
+            public SubresourceEndpoint(IEndpoint parent, string relativeUri) 
+                : base(parent, relativeUri)
+            {
+            }
+        }
+    }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -95,6 +95,7 @@
     <Compile Include="BulkCollectionEndpointTest.cs" />
     <Compile Include="CustomEndpointTest.cs" />
     <Compile Include="ElementEndpointTest.cs" />
+    <Compile Include="EndpointBaseTest.cs" />
     <Compile Include="EndpointTestBase.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hi Basti,

when using subresources from a specific element/resource item (i.e. `/resources/{id}/subresource`) the `{id}` will not be part of the whole uri (i.e. `/resources/subresource`).

So this pullrequest fixes this bug by just calling `parent.EnsureTrailingSlash().`.

I've also provided a unittest to proove this fix.

Cheers,
Andy

